### PR TITLE
fix: 1月度表示中に去年の12月の売上を追加すると1年後の売上になってしまうバグを修正

### DIFF
--- a/app/javascript/javascripts/score.js
+++ b/app/javascript/javascripts/score.js
@@ -22,6 +22,7 @@ document.addEventListener("turbolinks:load", function() {
   // start_dateをパラメーターから取得
   function setStartDate() {
     var start_date = getParam('start_date')
+    return start_date;
   };
 
   // クリックした日付の日付を取得して、ajaxで送信


### PR DESCRIPTION
#26 に対応
原因はstart_dateの値が正しく送られていなく、start_timeの年の値が現在日時の年になってしまっていた。