### PR TITLE
売上追加フォームや売上詳細が表示されないバグを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+.env

--- a/app/javascript/javascripts/score.js
+++ b/app/javascript/javascripts/score.js
@@ -44,7 +44,7 @@ document.addEventListener("turbolinks:load", function() {
   function getToday() {
     var now = new Date();
     var y = now.getFullYear();
-    var m = now.getMonth();
+    var m = now.getMonth() + 1;
     var d = now.getDate();
     var today = `${y}-${m}-${d}`
     return today


### PR DESCRIPTION
原因は、start_dateがクエリパラメータに無いときに今日の日付をstart_dateに設定する処理の中で、月が1ヶ月前にずれていた。 5/31に見ようとした際に、4/31になってしまい、4/31は存在しないのでinvalid dateになっていた。getMonth() + 1 することで解決。