### PR TITLE
売上詳細一覧ページのUIを調整

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -12,13 +12,17 @@ body {
 }
 
 .navbar {
+  background-color: #288af3;
   .navbar-brand {
     margin: auto auto auto 8px;
     a {
-      color: #495057;
-      border-left: 5px #007bff solid;
+      color: white;
+      border-left: 5px white solid;
       padding-left: 0.5rem;
     }
+  }
+  .nav-link {
+    color: white!important;
   }
   .dropdown-custom.dropdown-menu {
     position: absolute;

--- a/app/assets/stylesheets/score_details.scss
+++ b/app/assets/stylesheets/score_details.scss
@@ -1,11 +1,40 @@
+.texi-meter-buttons {
+  text-align: center;
+  margin: 1rem auto;
+  .btn {
+    color: white;
+    background-color: #007bff;
+    border-top:4px solid rgba(255,255,255,0.2);
+    border-bottom:4px solid rgba(0,0,0,0.2);
+    border-radius:4px;
+  }
+  .btn:active {
+    -webkit-transform: translate(0,4px);
+    -moz-transform: translate(0,4px);
+    transform: translate(0,4px);
+    border-bottom:none;
+  }
+}
+  
 table {
   counter-reset: rowCount;
+  background-color: white;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.07), 0 2px 4px rgba(0, 0, 0, 0.05);
+  border: none;
 }
 
 table > tbody > tr {
   counter-increment: rowCount;
 }
 
+table > tbody > tr > td {
+  border-left: none;
+  border-right: none;
+  border-bottom: solid 1px rgb(230, 230, 230);
+  padding: 1rem 0.3rem;
+}
+
 table > tbody > tr > td:first-child::before {
   content: counter(rowCount);
 }
+

--- a/app/assets/stylesheets/score_details.scss
+++ b/app/assets/stylesheets/score_details.scss
@@ -35,25 +35,31 @@
   }
 }
   
-table {
+.score-detail-table {
   counter-reset: rowCount;
   background-color: white;
   box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.07), 0 2px 4px rgba(0, 0, 0, 0.05);
   border: none;
 }
 
-table > tbody > tr {
+.score-detail-table > tbody > tr {
   counter-increment: rowCount;
+  cursor: pointer;
 }
 
-table > tbody > tr > td {
+.score-detail-table > tbody > .score-detail-tr:hover {
+  background-color: rgba(118, 203, 255, 0.7);
+}
+
+.score-detail-table > tbody > tr > td {
+  color: rgb(0, 123, 255);
   border-left: none;
   border-right: none;
   border-bottom: solid 1px rgb(230, 230, 230);
   padding: 1rem 0.3rem;
 }
 
-table > tbody > tr > td:first-child::before {
+.score-detail-table > tbody > tr > td:first-child::before {
   content: counter(rowCount);
 }
 

--- a/app/assets/stylesheets/score_details.scss
+++ b/app/assets/stylesheets/score_details.scss
@@ -78,6 +78,10 @@
   content: counter(rowCount);
 }
 
+.dropdown-toggle:after {
+  display: none;
+}
+
 @media (max-width: 767px) {
   .texi-meter {
     .meter-button {

--- a/app/assets/stylesheets/score_details.scss
+++ b/app/assets/stylesheets/score_details.scss
@@ -1,24 +1,38 @@
-.texi-meter-buttons {
+.texi-meter {
   text-align: center;
   margin: 1rem auto;
-  .btn {
-    color: white;
-    background-color: #007bff;
-    border-top:4px solid rgba(255,255,255,0.2);
-    border-bottom:4px solid rgba(0,0,0,0.2);
-    border-radius:4px;
-  }
-  .btn:active {
-    transform: translate(0,4px);
-    border-bottom: none;
+  .meter-button {
+    .btn {
+      color: white;
+      font-size: 2rem;
+      position: relative;
+      box-shadow: 0 5px 1px rgba(0,0,0,0.7);
+      border-radius:4px;
+    }
+    .pickup-button {
+      background-color: #007bff;
+    }
+    .dropoff-button {
+      background-color: #ef693f;
+    }
+    .btn:active {
+      top: 5px;
+      box-shadow: 0 1px 1px rgba(0,0,0,0.7);
+    }
+    .pickup-button:active {
+      background-color: #026de0;
+    }
+    .dropoff-button:active {
+      background-color: #cd5631;
+    }
   }
 }
 
-.meter {
+.meter-display {
   background-color: rgb(33, 33, 33);
   color: white;
   text-align: center;
-  margin: 0 auto 0.5rem auto;
+  margin: auto;
   width: 7rem;
   height: 3rem;
   line-height: 3rem;

--- a/app/assets/stylesheets/score_details.scss
+++ b/app/assets/stylesheets/score_details.scss
@@ -9,10 +9,29 @@
     border-radius:4px;
   }
   .btn:active {
-    -webkit-transform: translate(0,4px);
-    -moz-transform: translate(0,4px);
     transform: translate(0,4px);
-    border-bottom:none;
+    border-bottom: none;
+  }
+}
+
+.meter {
+  background-color: rgb(33, 33, 33);
+  color: white;
+  text-align: center;
+  margin: 0 auto 0.5rem auto;
+  width: 7rem;
+  height: 3rem;
+  line-height: 3rem;
+  p {
+    display: inline-block;
+  }
+  .meter-fare {
+    font-size: 1.5rem;
+  }
+  .extra-fee {
+    font-size: 0.5rem;
+    color: lightgreen;
+    margin-right: 0.2rem;
   }
 }
   

--- a/app/assets/stylesheets/score_details.scss
+++ b/app/assets/stylesheets/score_details.scss
@@ -8,6 +8,7 @@
       position: relative;
       box-shadow: 0 5px 1px rgba(0,0,0,0.7);
       border-radius:4px;
+      width: 60%;
     }
     .pickup-button {
       background-color: #007bff;
@@ -77,3 +78,12 @@
   content: counter(rowCount);
 }
 
+@media (max-width: 767px) {
+  .texi-meter {
+    .meter-button {
+      .btn {
+        width: 100%;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/score_details.scss
+++ b/app/assets/stylesheets/score_details.scss
@@ -82,6 +82,13 @@
   display: none;
 }
 
+.menus {
+  .dropdown-menu {
+    text-align: center;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.07), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  }
+}
+
 @media (max-width: 767px) {
   .texi-meter {
     .meter-button {

--- a/app/javascript/javascripts/score_details/clickable_tr.js
+++ b/app/javascript/javascripts/score_details/clickable_tr.js
@@ -1,0 +1,3 @@
+$(".score-detail-tr").on('click', function () {
+  window.location = $(this).data("href");
+});

--- a/app/javascript/javascripts/score_details/clickable_tr.js
+++ b/app/javascript/javascripts/score_details/clickable_tr.js
@@ -9,7 +9,7 @@ $(document).on('click', '.menus', function (e) {
 })
 
 $(document).on('click', function(e) {
-  if(!$(e.target).closest('.menus').length) {
+  if(!$(e.target).closest('.dropdown').length) {
     $('.dropdown-menu').removeClass('show');
   }
 })

--- a/app/javascript/javascripts/score_details/clickable_tr.js
+++ b/app/javascript/javascripts/score_details/clickable_tr.js
@@ -1,3 +1,15 @@
-$(".score-detail-tr").on('click', function () {
+$(document).on('click', '.score-detail-tr', function () {
   window.location = $(this).data("href");
 });
+
+$(document).on('click', '.menus', function (e) {
+  e.stopPropagation();
+  $(this).find('.dropdown-menu').toggleClass('show');
+  $('.menus').not($(this)).find('.dropdown-menu').removeClass('show');
+})
+
+$(document).on('click', function(e) {
+  if(!$(e.target).closest('.menus').length) {
+    $('.dropdown-menu').removeClass('show');
+  }
+})

--- a/app/javascript/javascripts/score_details/index.js
+++ b/app/javascript/javascripts/score_details/index.js
@@ -19,8 +19,11 @@ function initMap() {
   let meterDistance = 0;
   let oneMeter = true;
 
-  $('#pickup').click( () => {
-    status = "occupied"
+  $(document).on("click", "#pickup", function () {
+    status = "occupied";
+    $(".meter-button").html(
+      '<button id="dropoff" class="btn dropoff-button">支払い</button>'
+    )
     watchId = navigator.geolocation.watchPosition(
     $.throttle(5000, success),
       error => console.log(error),
@@ -30,8 +33,8 @@ function initMap() {
     );
   });
 
-  $("#dropoff").click( () => {
-    status = "vacant"
+  $(document).on("click", "#dropoff", function () {
+    status = "vacant";
     navigator.geolocation.clearWatch(watchId);
     dropoffLatLng = new google.maps.LatLng(coordinates[coordinates.length - 2], coordinates[coordinates.length - 1]);
     dropoffTime = timeStamps[timeStamps.length - 1];
@@ -111,9 +114,9 @@ function initMap() {
     console.log(timeStamps[timeStamps.length - 1]);
     console.log("メーター距離:" + meterDistance + "m");
     console.log(fare + "円");
-    $('.meter').html(`<p class="meter-fare">${fare}</p><p class="meter-yen">円</p>`);
+    $('.meter-display').html(`<p class="meter-fare">${fare}</p><p class="meter-yen">円</p>`);
     if (hour >= 22 || hour < 5) {
-      $('.meter').prepend(`<p class="extra-fee">割増</p>`);
+      $('.meter-display').prepend(`<p class="extra-fee">割増</p>`);
     }
   }
 
@@ -163,9 +166,12 @@ function initMap() {
     fare = 420;
     meterDistance = 0;
     oneMeter = true;
-    $('.meter').html(
+    $('.meter-display').html(
       '<p class="meter-fare">0</p><p class="meter-yen">円</p>'
     );
+    $(".meter-button").html(
+      '<button id="pickup" class="btn pickup-button">実車</button>'
+    )
   }
 
   function ajaxScoreDetail () {

--- a/app/javascript/javascripts/score_details/index.js
+++ b/app/javascript/javascripts/score_details/index.js
@@ -111,9 +111,9 @@ function initMap() {
     console.log(timeStamps[timeStamps.length - 1]);
     console.log("メーター距離:" + meterDistance + "m");
     console.log(fare + "円");
-    $('.meter').html(`<div>メーター料金: ${fare}円</div>`);
+    $('.meter').html(`<p class="meter-fare">${fare}</p><p class="meter-yen">円</p>`);
     if (hour >= 22 || hour < 5) {
-      $('.extra-fee').html(`<div>割増</div>`);
+      $('.meter').prepend(`<p class="extra-fee">割増</p>`);
     }
   }
 
@@ -142,7 +142,6 @@ function initMap() {
           if (timing == "pickup") {
             pickupTime = timeStamps[1];
             pickupAddress = `${city} ${area} ${block}`
-            // $('#js-addedList').remove();
             $('.js-added-pickup-time').replaceWith(
               `<td class="js-added-pickup-time">${format(pickupTime, 'HH:mm')}</td>`
             );
@@ -164,7 +163,9 @@ function initMap() {
     fare = 420;
     meterDistance = 0;
     oneMeter = true;
-    $('.meter').html("<div>メーター料金: 0円</div>");
+    $('.meter').html(
+      '<p class="meter-fare">0</p><p class="meter-yen">円</p>'
+    );
   }
 
   function ajaxScoreDetail () {

--- a/app/javascript/javascripts/score_details/index.js
+++ b/app/javascript/javascripts/score_details/index.js
@@ -65,12 +65,12 @@ function initMap() {
       $('.lists').append(
         `<tr class="js-addedList">
           <td></td>
-          <td class="js-added-pickup-time"></td>
-          <td class="js-added-dropoff-time"></td>
-          <td class="js-added-pickup-address">場所取得中</td>
-          <td class="js-added-dropoff-address"></td>
-          <td class="js-added-fare"></td>
-          <td class="js-added-delete-button"></td>
+          <td class="js-added-pickup-time pickup-time"></td>
+          <td class="js-added-dropoff-time dropoff-time"></td>
+          <td class="js-added-pickup-address pickup-address">場所取得中</td>
+          <td class="js-added-dropoff-address dropoff-address"></td>
+          <td class="js-added-fare fare"></td>
+          <td class="js-added-delete-button delete-button"></td>
         </tr>`
       )
     }

--- a/app/javascript/javascripts/score_details/index.js
+++ b/app/javascript/javascripts/score_details/index.js
@@ -66,10 +66,12 @@ function initMap() {
   function calcFare () {
     if (coordinates.length < 3) {
       $('.lists').append(
-        `<tr class="js-addedList">
+        `<tr class="js-added-list">
           <td></td>
-          <td class="js-added-pickup-time pickup-time"></td>
-          <td class="js-added-dropoff-time dropoff-time"></td>
+          <td class="js-added-time">
+            <div class="js-added-pickup-time"></div>
+            <div class="js-added-dropoff-time"></div>
+          </td>
           <td class="js-added-pickup-address pickup-address">場所取得中</td>
           <td class="js-added-dropoff-address dropoff-address"></td>
           <td class="js-added-fare fare"></td>
@@ -146,7 +148,7 @@ function initMap() {
             pickupTime = timeStamps[1];
             pickupAddress = `${city} ${area} ${block}`
             $('.js-added-pickup-time').replaceWith(
-              `<td class="js-added-pickup-time">${format(pickupTime, 'HH:mm')}</td>`
+              `<div class="js-added-pickup-time">${format(pickupTime, 'HH:mm')}</div>`
             );
             $('.js-added-pickup-address').replaceWith(
               `<td class="js-added-pickup-address">${pickupAddress}</td>`
@@ -191,7 +193,7 @@ function initMap() {
       }
     })
     .done(function(responce) {
-      $('.js-addedList').replaceWith(responce);
+      $('.js-added-list').replaceWith(responce);
       resetMeter();
     })
     .fail(function() {

--- a/app/javascript/packs/score_details/index_pack.js
+++ b/app/javascript/packs/score_details/index_pack.js
@@ -1,2 +1,3 @@
 import '../../javascripts/jquery.ba-throttle-debounce'
 import '../../javascripts/score_details/index'
+import '../../javascripts/score_details/clickable_tr'

--- a/app/views/score_details/_score_detail.html.erb
+++ b/app/views/score_details/_score_detail.html.erb
@@ -1,10 +1,10 @@
-<tr class="score-detail-<%= score_detail.id %>">
+<tr class="score-detail-tr score-detail-<%= score_detail.id %>" data-href="/scores/<%= score_detail.score_id %>/score_details/<%= score_detail.id %>">
   <td class="number"></td>
-  <td class="pickup-time"><%= link_to score_detail.pickup_time.strftime("%H:%M"), score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td class="dropoff-time"><%= link_to score_detail.dropoff_time.strftime("%H:%M"), score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td class="pickup-address"><%= link_to score_detail.pickup_address, score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td class="pickup-address"><%= link_to score_detail.dropoff_address, score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td class="fare"><%= link_to score_detail.fare, score_score_detail_path(score_detail.score_id, score_detail) %></td>
+  <td class="pickup-time"><%= score_detail.pickup_time.strftime("%H:%M") %></td>
+  <td class="dropoff-time"><%= score_detail.dropoff_time.strftime("%H:%M") %></td>
+  <td class="pickup-address"><%= score_detail.pickup_address %></td>
+  <td class="pickup-address"><%= score_detail.dropoff_address %></td>
+  <td class="fare"><%= score_detail.fare %></td>
   <td class="delete-button">
     <%= link_to score_score_detail_path(score_detail.score_id, score_detail), method: :delete, data: { confirm: '削除しますか？' }, remote: true do %>
       <span class="far fa-trash-alt"></span>

--- a/app/views/score_details/_score_detail.html.erb
+++ b/app/views/score_details/_score_detail.html.erb
@@ -1,12 +1,12 @@
 <tr class="score-detail-<%= score_detail.id %>">
-  <td></td>
-  <td><%= link_to score_detail.pickup_time.strftime("%H:%M"), score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td><%= link_to score_detail.dropoff_time.strftime("%H:%M"), score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td><%= link_to score_detail.pickup_address, score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td><%= link_to score_detail.dropoff_address, score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td><%= link_to score_detail.fare, score_score_detail_path(score_detail.score_id, score_detail) %></td>
-  <td>
-    <%= link_to score_score_detail_path(score_detail.score_id, score_detail), method: :delete, data: { confirm: '削除しますか？' }, class: "delete-button", remote: true do %>
+  <td class="number"></td>
+  <td class="pickup-time"><%= link_to score_detail.pickup_time.strftime("%H:%M"), score_score_detail_path(score_detail.score_id, score_detail) %></td>
+  <td class="dropoff-time"><%= link_to score_detail.dropoff_time.strftime("%H:%M"), score_score_detail_path(score_detail.score_id, score_detail) %></td>
+  <td class="pickup-address"><%= link_to score_detail.pickup_address, score_score_detail_path(score_detail.score_id, score_detail) %></td>
+  <td class="pickup-address"><%= link_to score_detail.dropoff_address, score_score_detail_path(score_detail.score_id, score_detail) %></td>
+  <td class="fare"><%= link_to score_detail.fare, score_score_detail_path(score_detail.score_id, score_detail) %></td>
+  <td class="delete-button">
+    <%= link_to score_score_detail_path(score_detail.score_id, score_detail), method: :delete, data: { confirm: '削除しますか？' }, remote: true do %>
       <span class="far fa-trash-alt"></span>
     <% end %>
   </td>

--- a/app/views/score_details/_score_detail.html.erb
+++ b/app/views/score_details/_score_detail.html.erb
@@ -1,7 +1,13 @@
 <tr class="score-detail-tr score-detail-<%= score_detail.id %>" data-href="/scores/<%= score_detail.score_id %>/score_details/<%= score_detail.id %>">
   <td class="number"></td>
-  <td class="pickup-time"><%= score_detail.pickup_time.strftime("%H:%M") %></td>
-  <td class="dropoff-time"><%= score_detail.dropoff_time.strftime("%H:%M") %></td>
+  <td class="time">
+    <div class="pickup-time">
+      <%= score_detail.pickup_time.strftime("%H:%M") %>
+    </div>
+    <div class="dropoff-time">
+      <%= score_detail.dropoff_time.strftime("%H:%M") %>
+    </div>
+  </td>
   <td class="pickup-address"><%= score_detail.pickup_address %></td>
   <td class="pickup-address"><%= score_detail.dropoff_address %></td>
   <td class="fare"><%= score_detail.fare %></td>

--- a/app/views/score_details/_score_detail.html.erb
+++ b/app/views/score_details/_score_detail.html.erb
@@ -9,11 +9,21 @@
     </div>
   </td>
   <td class="pickup-address"><%= score_detail.pickup_address %></td>
-  <td class="pickup-address"><%= score_detail.dropoff_address %></td>
+  <td class="dropoff-address"><%= score_detail.dropoff_address %></td>
   <td class="fare"><%= score_detail.fare %></td>
-  <td class="delete-button">
-    <%= link_to score_score_detail_path(score_detail.score_id, score_detail), method: :delete, data: { confirm: '削除しますか？' }, remote: true do %>
-      <span class="far fa-trash-alt"></span>
-    <% end %>
+  <td class="menus">
+    <div class="dropdown">
+      <span id="dropdown1" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+        <i class="fa fa-ellipsis-h"></i>
+      </span>
+      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown1">
+        <%= link_to edit_score_score_detail_path(score_detail.score_id, score_detail), class: 'dropdown-item edit-link', remote: true do %>
+          <button class="btn btn-success"><span class="fas fa-edit"></span> 編集する</button>
+        <% end %>
+        <%= link_to score_score_detail_path(score_detail.score_id, score_detail), class: 'dropdown-item delete-link', method: :delete, data: { confirm: '削除しますか？' }, remote: true do %>
+          <button class="btn btn-danger"><span class="far fa-trash-alt"></span> 削除する</button>
+        <% end %>
+      </div>
+    </div>
   </td>
 </tr>

--- a/app/views/score_details/_score_detail.html.erb
+++ b/app/views/score_details/_score_detail.html.erb
@@ -1,6 +1,6 @@
 <tr class="score-detail-tr score-detail-<%= score_detail.id %>" data-href="/scores/<%= score_detail.score_id %>/score_details/<%= score_detail.id %>">
-  <td class="number"></td>
-  <td class="time">
+  <td class="number" width="5%"></td>
+  <td class="time" width="10%">
     <div class="pickup-time">
       <%= score_detail.pickup_time.strftime("%H:%M") %>
     </div>
@@ -8,21 +8,17 @@
       <%= score_detail.dropoff_time.strftime("%H:%M") %>
     </div>
   </td>
-  <td class="pickup-address"><%= score_detail.pickup_address %></td>
-  <td class="dropoff-address"><%= score_detail.dropoff_address %></td>
-  <td class="fare"><%= score_detail.fare %></td>
-  <td class="menus">
+  <td class="pickup-address" width="30%"><%= score_detail.pickup_address %></td>
+  <td class="dropoff-address" width="30%"><%= score_detail.dropoff_address %></td>
+  <td class="fare" width="13%"><%= score_detail.fare %></td>
+  <td class="menus" width="12%">
     <div class="dropdown">
       <span id="dropdown1" class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">
         <i class="fa fa-ellipsis-h"></i>
       </span>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown1">
-        <%= link_to edit_score_score_detail_path(score_detail.score_id, score_detail), class: 'dropdown-item edit-link', remote: true do %>
-          <button class="btn btn-success"><span class="fas fa-edit"></span> 編集する</button>
-        <% end %>
-        <%= link_to score_score_detail_path(score_detail.score_id, score_detail), class: 'dropdown-item delete-link', method: :delete, data: { confirm: '削除しますか？' }, remote: true do %>
-          <button class="btn btn-danger"><span class="far fa-trash-alt"></span> 削除する</button>
-        <% end %>
+        <%= link_to "編集", edit_score_score_detail_path(score_detail.score_id, score_detail), class: 'edit-link btn btn-success', remote: true %>
+        <%= link_to "削除", score_score_detail_path(score_detail.score_id, score_detail), class: 'delete-link btn btn-danger', method: :delete, data: { confirm: '削除しますか？' }, remote: true %>
       </div>
     </div>
   </td>

--- a/app/views/score_details/index.html.erb
+++ b/app/views/score_details/index.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <div class="row">
-    <table border="1" class="col-12">
+    <table border="1" class="score-detail-table col-12">
       <tbody class="lists">
         <%= render @score_details %>
       </tbody>

--- a/app/views/score_details/index.html.erb
+++ b/app/views/score_details/index.html.erb
@@ -1,14 +1,23 @@
 <body>
-  <button id="pickup" style="font-size: 50px">pickup</button>
-  <button id="dropoff" style="font-size: 50px">dropoff</button>
+  <div class="texi-meter-buttons row">
+    <div class="col-6">
+      <button id="pickup" class="btn" style="font-size: 30px">pickup</button>
+    </div>
+    <div class="col-6">
+      <button id="dropoff" class="btn" style="font-size: 30px">dropoff</button>
+    </div>
+  </div>
+
   <div class="extra-fee"></div>
   <div class="meter">メーター料金: 0円</div>
 
-  <table border="1">
-    <tbody class="lists">
-      <%= render @score_details %>
-    </tbody>
-  </table>
+  <div class="row">
+    <table border="1" class="col-12">
+      <tbody class="lists">
+        <%= render @score_details %>
+      </tbody>
+    </table>
+  </div>
 
   <%= javascript_pack_tag 'score_details/index_pack' %>
   <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap"></script>

--- a/app/views/score_details/index.html.erb
+++ b/app/views/score_details/index.html.erb
@@ -1,16 +1,12 @@
 <body>
-  <div class="texi-meter-buttons row">
-    <div class="col-6">
-      <button id="pickup" class="btn" style="font-size: 30px">pickup</button>
+  <div class="texi-meter row">
+    <div class="meter-display col-6">
+      <p class="meter-fare">0</p>
+      <p class="meter-yen">円</p>
     </div>
-    <div class="col-6">
-      <button id="dropoff" class="btn" style="font-size: 30px">dropoff</button>
+    <div class="meter-button col-6">
+      <button id="pickup" class="btn pickup-button">実車</button>
     </div>
-  </div>
-
-  <div class="meter">
-    <p class="meter-fare">0</p>
-    <p class="meter-yen">円</p>
   </div>
 
   <div class="row">

--- a/app/views/score_details/index.html.erb
+++ b/app/views/score_details/index.html.erb
@@ -8,8 +8,10 @@
     </div>
   </div>
 
-  <div class="extra-fee"></div>
-  <div class="meter">メーター料金: 0円</div>
+  <div class="meter">
+    <p class="meter-fare">0</p>
+    <p class="meter-yen">円</p>
+  </div>
 
   <div class="row">
     <table border="1" class="col-12">


### PR DESCRIPTION
売上詳細一覧ページのUIを調整しました。 #53 
- タクシーメーターのボタン(実車と支払い)を押したら切り替わるように変更
- 売上詳細をテーブルにし、行全体を売上詳細ページへのリンクにした #54 
- 売上詳細の編集と削除ボタンをドロップダウンで開閉できるように変更