### PR TITLE
デザインを調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@
 @import "simple_calendar";
 @import "common";
 @import "scores";
+@import "users";
 @import "score_details";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -34,7 +34,7 @@ body {
 
 .flash-messages {
   width: max-content;
-  margin: auto;
+  margin: auto auto 2rem auto;
 }
 
 .container-xl {
@@ -54,7 +54,7 @@ body {
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.07), 0 2px 4px rgba(0, 0, 0, 0.05);
     h1 {
       font-size: 2rem;
-      margin-bottom: 1rem;
+      margin-bottom: 2rem;
     }
     .error-messages-field {
       max-width: 90vw;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -49,6 +49,9 @@ body {
   justify-content: center;
   align-items: center;
   .form-area {
+    padding: 3rem;
+    background-color: white;
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.07), 0 2px 4px rgba(0, 0, 0, 0.05);
     h1 {
       font-size: 2rem;
       margin-bottom: 1rem;
@@ -71,11 +74,6 @@ body {
       margin: 1rem 0;
     }
   }
-}
-
-.login-page {
-  position: relative;
-  top: -3rem;
 }
 
 @media (max-width: 767px) {

--- a/app/helpers/scores_helper.rb
+++ b/app/helpers/scores_helper.rb
@@ -16,6 +16,7 @@ module ScoresHelper
     today = Date.current
 
     td_class = ["day"]
+    td_class << day.to_date
     td_class << "wday-#{day.wday}"
     td_class << "today" if today == day
     td_class << "past" if today > day
@@ -25,7 +26,6 @@ module ScoresHelper
     td_class << "next-month" if dates_in_this_month.exclude?(day) && day > dates_in_this_month.last
     td_class << "current-month" if start_date.month == day.month
     td_class << "has-events" if sorted_events.fetch(day, []).any?
-    td_class << day.to_date
 
     td_class
   end

--- a/app/javascript/javascripts/score.js
+++ b/app/javascript/javascripts/score.js
@@ -23,7 +23,7 @@ $(function () {
 
   const getStartTime = (selector) => {
     const classes = $(selector).attr('class').split(" ");
-    return classes[classes.length - 1];
+    return classes[1];
   };
 
   // ----------月度ジャンプの開閉

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,6 @@
     <%= render 'shared/header'%>
   <% end %>
   <div class="container-xl">
-    <%= render 'shared/flash_message' %>
     <%= yield %>
   </div>
 </html>

--- a/app/views/scores/create.js.erb
+++ b/app/views/scores/create.js.erb
@@ -5,5 +5,5 @@ $(".error-messages-field").remove()
 $('.<%= @score.start_time.to_date %>').addClass("has-events")
 $('.<%= @score.start_time.to_date %>').html("<%= j(render('calendar_td', score: @score)) %>")
 $('.new-score-form').replaceWith("<%= j(render('scores/searches/score', searched_score: @score)) %>")
-$('.js-searched-score').prepend('<div class="flash-messages alert alert-success"><%= @success_message %></div>')
+$('.js-searched-score').prepend('<div class="flash-messages alert alert-success" style="margin: auto;"><%= @success_message %></div>')
 <% end %>

--- a/app/views/scores/update.js.erb
+++ b/app/views/scores/update.js.erb
@@ -5,5 +5,5 @@ $(".error-messages-field").remove();
 $('.<%= @score.start_time.to_date %>').addClass("has-events")
 $('.<%= @score.start_time.to_date %>').html("<%= j(render('calendar_td', score: @score)) %>")
   $('.new-score-form').replaceWith("<%= j(render('scores/searches/score', searched_score: @score)) %>")
-  $('.js-searched-score').prepend('<div class="flash-messages alert alert-success"><%= @success_message %></div>')
+  $('.js-searched-score').prepend('<div class="flash-messages alert alert-success" style="margin: auto;"><%= @success_message %></div>')
 <% end %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,6 @@
 <div class="form-page text-center login-page">
   <main class="form-area">
+    <%= render 'shared/flash_message' %>
     <h1>ログイン</h1>
     <%= form_with url: login_path, local:true do |f| %>
       <div class="form-group">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,6 @@
 <div class="profile-page text-center mypage">
   <main>
+    <%= render 'shared/flash_message' %>
     <h1>プロフィール</h1>
     <%= link_to '編集', edit_user_path(@user), class: 'btn btn-primary' %>
     <table class="table">


### PR DESCRIPTION
ログイン、ユーザー登録、ユーザー編集ページのデザインや、フラッシュメッセージの位置を調整しました。
また、カレンダーページで売上を追加した直後にリロードせずにその日付を選択すると、詳細が表示されない問題を修正しました。